### PR TITLE
Paste glyph image functionality

### DIFF
--- a/public/glyph.html
+++ b/public/glyph.html
@@ -158,11 +158,11 @@
 
                 <div class="row">
                     <div class="col-md-2 col-4 txt-label-def" data-toggle="tooltip" data-html="true"
-                        data-placement="bottom" title="Load unmodified screenshot containing glyphs. ALWAYS double check results.">
+                        data-placement="bottom" title="Load or paste unmodified screenshot containing glyphs. ALWAYS double check results.">
                         Screenshot&nbsp;
                         <i class="bx bx-help-circle text-danger h6"></i>
                     </div>
-                    <input type="file" class="col-4 form-control form-control-sm" accept="image/*" name="files[]"
+                    <input id="file-input" type="file" class="col-4 form-control form-control-sm" accept="image/*" name="files[]"
                         data-type="img" onchange="glyph.loadGlyphImage(this)">
                     <div class="col-14">
                         <canvas id="ss-canvas" class="border" style="height:10px;width:20px;"></canvas>

--- a/public/glyph.js
+++ b/public/glyph.js
@@ -95,3 +95,13 @@ function displayAll(addr, planet) {
     $("#addr-card #id-addr").val(addr)
     $("#addr-card #id-planet").val(planet)
 }
+
+$(window).on('paste', (event) => {
+    const paste = event.originalEvent.clipboardData.files;
+    const file = Array.from(paste).find(file => /^image\//.test(file.type));
+
+    const transfer = new DataTransfer();
+    if (file) transfer.items.add(file);
+
+    if (transfer.files.length) $('#file-input').prop('files', transfer.files).trigger('change');
+});


### PR DESCRIPTION
> Once again, apologies on if formatting is undesirable, there appear to be no templates.


Resolves #31: Suggested Feat: Pasting images into Glyph to Coordinates
